### PR TITLE
[CIR-AddHelperScripts] Some script updates and helpers to simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,11 @@ docker run -d --rm --name postgresql -e POSTGRES_USER=postgres -e POSTGRES_PASSW
 If you are running postgres natively (not in docker) then ensure that the `POSTGRES_USER` and `POSTGRES_PASSWORD` values above, and the `username` and `password` `sm` settings
 below, are set appropriately.
 
-To start services locally, run the following:
+**IMPORTANT**
+To start dependent services locally, run the following script:
+
 ```bash
-sm2 --start ADDRESS_LOOKUP_SERVICES --appendArgs '{
-    "ADDRESS_LOOKUP":[
-        "-Dauditing.enabled=false",
-        "-Dmicroservice.services.access-control.enabled=false"
-    ],
-    "ADDRESS_SEARCH_API": [
-        "-Dauditing.enabled=false",
-        "-Dmicroservice.address-search-api.rds.enabled=true",
-        "-Dmicroservice.address-search-api.rds.url=jdbc:postgresql://localhost:5432/",
-        "-Dmicroservice.address-search-api.rds.username=postgres",
-        "-Dmicroservice.address-search-api.rds.password=postgres"
-    ]
-}'
+./start_services.sh
 ```
 
 NOTE: The db connection parameters for `address-lookup` service - this is to ensure that it connects to the docker container running locally and to the sidecar container when

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-BROWSER=$1
-ENVIRONMENT=$2
+BROWSER=${1:-chrome}
+ENVIRONMENT=${2:-local}
+HEADLESS=${3:-true}
+SPECS=${4:-"uk.gov.hmrc.ui.specs.*"}
 
-sbt clean -Dbrowser="${BROWSER:=chrome}" -Denvironment="${ENVIRONMENT:=local}" test testReport
+sbt clean -Dbrowser=${BROWSER} -Denvironment=${ENVIRONMENT} -Dbrowser.option.headless=${HEADLESS} "testOnly ${SPECS}" testReport

--- a/start_services.sh
+++ b/start_services.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+sm2 --start ADDRESS_LOOKUP_SERVICES --appendArgs '{
+    "ADDRESS_LOOKUP":[
+        "-Dauditing.enabled=false",
+        "-Dmicroservice.services.access-control.enabled=false"
+    ],
+    "ADDRESS_SEARCH_API": [
+        "-Dauditing.enabled=false",
+        "-Dmicroservice.address-search-api.rds.enabled=true",
+        "-Dmicroservice.address-search-api.rds.url=jdbc:postgresql://localhost:5432/",
+        "-Dmicroservice.address-search-api.rds.username=postgres",
+        "-Dmicroservice.address-search-api.rds.password=postgres"
+    ],
+    "ADDRESS_LOOKUP_FRONTEND": [
+        "-Dmicroservice.selectPageConfig.showNoneOfTheseOption=true"
+    ]
+}'


### PR DESCRIPTION
This pull request streamlines the process for starting local services and running tests by introducing a dedicated startup script and enhancing the test runner script. The changes improve usability and make local development setup more consistent.

**Local service startup improvements:**

* Added a new `start_services.sh` script to encapsulate the logic for starting dependent services with the correct arguments, making the setup process easier and less error-prone. (`start_services.sh`)
* Updated the `README.md` to instruct users to use the new `start_services.sh` script instead of manually running the `sm2` command, and clarified the startup instructions. (`README.md`)

**Test runner enhancements:**

* Modified `run-tests.sh` to accept optional arguments for browser, environment, headless mode, and test specs, with sensible defaults for each parameter. This makes running tests more flexible and user-friendly. (`run-tests.sh`)