### PR TITLE
CIR-2879 Update to manual address max length error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ docker run --rm -d -p 27017:27017 --name mongo percona/percona-server-mongodb:5.
 If you don't have postgres installed locally you can run it in docker using the following command
 
 ```bash
-docker run -d --rm --name postgresql -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:10.14
+docker run --name postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432 postgres
 ```
 
 If you are running postgres natively (not in docker) then ensure that the `POSTGRES_USER` and `POSTGRES_PASSWORD` values above, and the `username` and `password` `sm` settings
 below, are set appropriately.
 
 **IMPORTANT**
-To start dependent services locally, run the following script:
+To start dependent services locally via service manager (sm2), run the following script:
 
 ```bash
 ./start_services.sh

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     "org.scalatestplus"      %% "selenium-4-21"          % "3.2.19.0"    % Test,
     "org.slf4j"               % "slf4j-simple"           % "2.0.17"      % Test,
     "com.typesafe.play"      %% "play-ahc-ws-standalone" % "2.2.14"      % Test,
-    "uk.gov.hmrc"            %% "ui-test-runner"         % "0.52.0"      % Test,
+    "uk.gov.hmrc"            %% "ui-test-runner"         % "0.54.0"      % Test,
     "org.tpolecat"           %% "doobie-core"            % doobieVersion % Test,
     "org.tpolecat"           %% "doobie-postgres"        % doobieVersion % Test,
     "org.tpolecat"           %% "doobie-scalatest"       % doobieVersion % Test,

--- a/src/test/scala/uk/gov/hmrc/ui/specs/ManualAddressEntrySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/specs/ManualAddressEntrySpec.scala
@@ -266,8 +266,8 @@ class ManualAddressEntrySpec extends BaseSpec {
 
       Then("I should see field level error messages as well as a clickable 'Error Summary' at the top of the page")
       checkErrorMessages(
-        lineOneError = Some("The first address line needs to be fewer than 256 characters"),
-        townError = Some("The town or city needs to be fewer than 256 characters"),
+        lineOneError = Some("Address line 1 needs to be 255 characters or less"),
+        townError = Some("Town or city needs to be 255 characters or less"),
         postCodeError = Some("Enter a valid postcode")
       )
       assertErrorMessageSummaryCountIsEqualTo(3)


### PR DESCRIPTION
This pull request updates the error messages in the `ManualAddressEntrySpec` test to align with new validation requirements for address fields. The changes clarify and standardize the wording and character limits for address validation errors.

Validation message updates:

* Updated error messages for `lineOneError` and `townError` in `ManualAddressEntrySpec.scala` to state "255 characters or less" instead of "fewer than 256 characters," and clarified the field names ("Address line 1" and "Town or city").

This PR supports the changes in https://github.com/hmrc/address-lookup-frontend/pull/201
